### PR TITLE
If no config file is found, use defaults

### DIFF
--- a/qstatpretty/config.py
+++ b/qstatpretty/config.py
@@ -14,7 +14,17 @@ CONFIGS_ORDER = [
 
 def get_config(configs_order=CONFIGS_ORDER):
     parser = configparser.SafeConfigParser()
-    parser.read(configs_order)
-    cfg = parser.items('defaults')
+    try:
+        parser.read(configs_order)
+        cfg = parser.items('defaults')
+    except:
+        cfg = {
+            'flavor': 'gridengine',
+            'table_algorithm': 'grow',
+            'delimiters': 'minimal',
+            'source': 'local',
+            'source_ssh_hostname': '',
+            'source_file_path': '' 
+        }
 
     return dict(cfg)


### PR DESCRIPTION
If the config file can't be opened, use the set of defaults listed in the file.  Using the config file or command line arguments should override these.
